### PR TITLE
fix build errors on OSX, add backup filenames to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.o
+**/backup.img
+**/device.conf

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC		= gcc -m32
+CC		= gcc -m64
 
 VERSION         = 1.4
 CFLAGS		= -g -O -Wall -Werror -DVERSION='"$(VERSION)"'
@@ -9,8 +9,8 @@ SRCS		= main.c util.c radio.c uv-5r.c uv-b5.c bf-888s.c ft-60r.c
 LIBS            =
 
 # Mac OS X
-CFLAGS          += -I/opt/local/include
-LIBS            += -L/opt/local/lib -lintl
+CFLAGS          += -I/usr/local/opt/gettext/include
+LIBS            += -L/usr/local/opt/gettext/lib -lintl
 
 all:		baoclone
 


### PR DESCRIPTION
PR to get project building on OSX. I get linker errors with -m32, so switched to -m64.